### PR TITLE
Reduce image size, bump pylint packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.6.1
+FROM python:3.6-alpine
 
-RUN useradd --system --user-group linter
+RUN addgroup -S linter && adduser -S -G linter linter
 
 COPY requirements.txt /
 RUN pip install -r /requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,10 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 flake8-blind-except==0.1.1
-flake8-debugger==1.4.0
+flake8-debugger==3.1.0
 flake8-imports==0.1.1
-flake8==3.4.1
-isort==4.2.15
+flake8==3.5.0
+isort==4.3.4
 mccabe==0.6.1
-pycodestyle==2.3.1        # via flake8
-pyflakes==1.5.0           # via flake8
+pycodestyle==2.3.1        # via flake8, flake8-debugger
+pyflakes==1.6.0           # via flake8


### PR DESCRIPTION
This avoids the download of 800MB on new build nodes.